### PR TITLE
Extend tests

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -1,5 +1,7 @@
 {
     "symbol-whitelist" : [
+        "Doctrine\\Common\\Annotations\\DocLexer",
+        "Doctrine\\Common\\Lexer\\Token",
         "Symfony\\Component\\EventDispatcher\\Event",
         "Symfony\\Contracts\\EventDispatcher\\Event",
         "Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface",

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,6 @@
         "ext-tokenizer": "*",
         "composer/semver": "^3.3",
         "composer/xdebug-handler": "^3.0.3",
-        "doctrine/annotations": "^2",
-        "doctrine/lexer": "^2 || ^3",
         "sebastian/diff": "^4.0 || ^5.0",
         "symfony/console": "^5.4 || ^6.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
@@ -40,6 +38,8 @@
         "symfony/stopwatch": "^5.4 || ^6.0"
     },
     "require-dev": {
+        "doctrine/annotations": "^2",
+        "doctrine/lexer": "^2 || ^3",
         "facile-it/paraunit": "^1.3 || ^2.0",
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^2.0",
@@ -58,7 +58,9 @@
     },
     "suggest": {
         "ext-dom": "For handling output formats in XML",
-        "ext-mbstring": "For handling non-UTF8 characters."
+        "ext-mbstring": "For handling non-UTF8 characters.",
+        "doctrine/annotations": "Required (^2) if you want to use @DoctrineAnnotation rule set (or single fixers related to Doctrine Annotations)",
+        "doctrine/lexer": "Required (^2 || ^3) if you want to use @DoctrineAnnotation rule set (or single fixers related to Doctrine Annotations)"
     },
     "autoload": {
         "psr-4": {

--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -41,6 +41,13 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
+        if (
+            !class_exists('Doctrine\Common\Annotations\DocLexer')
+            || !class_exists('Doctrine\Common\Lexer\Token')
+        ) {
+            throw new \RuntimeException('You need to install `doctrine/annotations` and `doctrine/lexer` to be able to use '.static::class);
+        }
+
         // fetch indices one time, this is safe as we never add or remove a token during fixing
         $analyzer = new TokensAnalyzer($tokens);
         $this->classyElements = $analyzer->getClassyElements();

--- a/tests/AutoReview/ComposerFileTest.php
+++ b/tests/AutoReview/ComposerFileTest.php
@@ -65,6 +65,22 @@ final class ComposerFileTest extends TestCase
         }
     }
 
+    public function testDoctrineSuggestionsContainProperVersionConstraints(): void
+    {
+        $composerJson = self::readComposerJson();
+        $doctrinePackages = ['doctrine/annotations', 'doctrine/lexer'];
+
+        foreach ($doctrinePackages as $package) {
+            $suggestion = $composerJson['suggest'][$package];
+            $constraint = $composerJson['require-dev'][$package];
+
+            self::assertSame(
+                "Required ({$constraint}) if you want to use @DoctrineAnnotation rule set (or single fixers related to Doctrine Annotations)",
+                $suggestion
+            );
+        }
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
The 2nd test (`yield ['^1', '^2'];`) is to make sure no internal error is happening.